### PR TITLE
feat(recorder): replace manual argv parsing with argparse CLI and add output/verbose options

### DIFF
--- a/app/recorder/src/main.cpp
+++ b/app/recorder/src/main.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <format>
 #include <fstream>
 #include <iostream>
 #include <string>

--- a/app/recorder/src/main.cpp
+++ b/app/recorder/src/main.cpp
@@ -5,6 +5,8 @@
 #include <thread>
 #include <vector>
 
+#include <argparse/argparse.hpp>
+
 #include <poc/clipboard.hpp>
 #include <poc/item.hpp>
 #include <poc/platform.hpp>
@@ -116,19 +118,21 @@ private:
 
 auto main(int argc, char* argv[]) -> int
 {
-    if (argc < 2)
-    {
-        std::cerr << "[-] Usage: " << argv[0] << " <output_file> [-v]\n";
-        return 1;
-    }
+    argparse::ArgumentParser cli{"Path of Crafting - Recorder"};
 
-    bool verbose = false;
-    if (argc >= 3 && std::string_view(argv[2]) == "-v")
-    {
-        verbose = true;
-    }
+    cli.add_argument("-o", "--output")
+        .help("Path to the output file where recorded items will be saved.")
+        .default_value(std::format("{:%Y-%m-%dT%H-%M-%S}.pocr", poc::recorder::clock::now()))
+        .metavar("FILE");
 
-    poc::recorder recorder(argv[1], verbose);
+    cli.add_argument("-v", "--verbose")
+        .help("Enable verbose output.")
+        .default_value(false)
+        .implicit_value(true);
+
+    cli.parse_args(argc, argv);
+
+    poc::recorder recorder(cli.get("output"), cli.get<bool>("verbose"));
     recorder.run();
     return 0;
 }

--- a/app/recorder/xmake.lua
+++ b/app/recorder/xmake.lua
@@ -1,6 +1,7 @@
 target("poc.recorder")
     set_kind("binary")
 
+    add_packages("argparse")
     add_deps("poc")
 
     add_files("src/**.cpp")

--- a/xmake.lua
+++ b/xmake.lua
@@ -9,7 +9,7 @@ set_warnings("allextra", "error")
 add_rules("mode.debug", "mode.release", "mode.coverage")
 add_rules("plugin.compile_commands.autoupdate", { outputdir = get_config("builddir") })
 
-add_requires("doctest")
+add_requires("argparse", "doctest")
 
 option("junit_reports")
     set_default(false)


### PR DESCRIPTION
Introduce argparse-based argument parsing (--output/-o, --verbose/-v) with a timestamped default output filename and update xmake deps to include argparse to improve CLI robustness and usability.
